### PR TITLE
without the if defined? this fails on chef12

### DIFF
--- a/providers/install.rb
+++ b/providers/install.rb
@@ -2,7 +2,7 @@ require 'securerandom'
 
 action :run do
 
-  use_inline_resources
+  use_inline_resources if defined?(use_inline_resources)
 
   service_name = new_resource.name
 


### PR DESCRIPTION
I think it should likely be a few lines above in the beginning of the provider; but without the if defined?() you'll break on older versions of chef

