### PR TITLE
multiple upstreams should be separated with commas in config file

### DIFF
--- a/templates/default/proxy.conf.erb
+++ b/templates/default/proxy.conf.erb
@@ -2,9 +2,7 @@ http_address = "<%= @listen_address %>"
 redirect_url = "<%= @redirect_url %>"
 
 upstreams = [
-<% @upstreams.each do |u| %>
-  "<%= u %>"
-<% end %>
+  <%= @upstreams.map{|upstream| "\"#{upstream}\""}.join(",\n  ") %>
 ]
 pass_basic_auth = <%= @pass_basic_auth %> 
 


### PR DESCRIPTION
Multiple upstream addresses should have commas between them in the config file, the existing template is invalid for more than one upstream address.
